### PR TITLE
fix!: remove the `-c/-C' shortcut from the `clipboard' cli option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ Options:
                                   The format of the links to be generated.  [default: plain]
   -t, --thumbnail                 Create captioned thumbnails. By default, in bbcode format.
   -n, --notify                    Send desktop notification on completion. Required libnotify.
-  -c, --clipboard / -C, --no-clipboard
-                                  Copy the result to the clipboard. Enabled by default.
+  --clipboard / --no-clipboard    Copy the result to the clipboard.  [default: clipboard]
   --env-file FILE                 The path to the environment file. Takes precedence over the default config file.
   --log-level [DEBUG|INFO|WARNING|ERROR|CRITICAL]
                                   Use DEBUG to show debug logs. Use CRITICAL to suppress all logs.  [default: INFO]

--- a/src/images_upload_cli/cli.py
+++ b/src/images_upload_cli/cli.py
@@ -43,12 +43,10 @@ from images_upload_cli.util import get_config_path, notify_send
     help="Send desktop notification on completion. Required libnotify.",
 )
 @click.option(
-    "-c/-C",
     "--clipboard/--no-clipboard",
     is_flag=True,
     default=True,
-    show_default=False,
-    help="Copy the result to the clipboard. Enabled by default.",
+    help="Copy the result to the clipboard.",
 )
 @click.option(
     "--env-file",


### PR DESCRIPTION
* fix!: remove the `-c/-C' shortcut from the `clipboard' cli option