### PR TITLE
feat: add `cloudinary`, `gofile`, `imagekit`, `imghippo`

### DIFF
--- a/Makefile.test.mk
+++ b/Makefile.test.mk
@@ -1,6 +1,6 @@
 .PHONY: test run
 
-HOSTINGS := beeimg catbox fastpic freeimage gyazo imageban imgbb imgbox imgchest imgur lensdump pixeldrain pixhost postimages ptpimg sxcu thumbsnap tixte uplio uploadcare vgy zpic
+HOSTINGS := beeimg catbox cloudinary fastpic freeimage gyazo imageban imagekit imgbb imghippo imgbox imgchest imgur lensdump pixeldrain pixhost postimages ptpimg sxcu thumbsnap tixte uplio uploadcare vgy zpic
 TEST_IMG := tests/fixtures/image.png
 
 run:

--- a/Makefile.test.mk
+++ b/Makefile.test.mk
@@ -1,6 +1,6 @@
 .PHONY: test run
 
-HOSTINGS := beeimg catbox cloudinary fastpic freeimage gyazo imageban imagekit imgbb imghippo imgbox imgchest imgur lensdump pixeldrain pixhost postimages ptpimg sxcu thumbsnap tixte uplio uploadcare vgy zpic
+HOSTINGS := beeimg catbox cloudinary fastpic freeimage gofile gyazo imageban imagekit imgbb imghippo imgbox imgchest imgur lensdump pixeldrain pixhost postimages ptpimg sxcu thumbsnap tixte uplio uploadcare vgy zpic
 TEST_IMG := tests/fixtures/image.png
 
 run:

--- a/README.md
+++ b/README.md
@@ -23,30 +23,33 @@ yay -S imgup-bin
 
 ## Hostings
 
-| host                                  | key required | return example                                       |
-| :------------------------------------ | :----------: | :--------------------------------------------------- |
-| [beeimg](https://beeimg.com/)         |      -       | `https://beeimg.com/images/{id}.png`                 |
-| [catbox](https://catbox.moe/)         |      -       | `https://files.catbox.moe/{id}`                      |
-| [fastpic](https://fastpic.org/)       |      -       | `https://i120.fastpic.org/big/2022/0730/d9/{id}.png` |
-| [freeimage](https://freeimage.host/)  |      +       | `https://iili.io/{id}.png`                           |
-| [gyazo](https://gyazo.com/)           |      +       | `https://i.gyazo.com/{id}.png`                       |
-| [imageban](https://imageban.ru/)      |      +       | `https://i2.imageban.ru/out/2022/07/30/{id}.png`     |
-| [imgbb](https://imgbb.com/)           |      +       | `https://i.ibb.co/{id}/image.png`                    |
-| [imgbox](https://imgbox.com/)         |      -       | `https://images2.imgbox.com/52/8c/{id}_o.png`        |
-| [imgchest](https://imgchest.com/)     |      +       | `https://cdn.imgchest.com/files/{id}.png`            |
-| [imgur](https://imgur.com/)           |      -       | `https://i.imgur.com/{id}.png`                       |
-| [lensdump](https://lensdump.com/)     |      +       | `https://i.lensdump.com/i/{id}.png`                  |
-| [pixeldrain](https://pixeldrain.com/) |      +       | `https://pixeldrain.com/api/file/{id}`               |
-| [pixhost](https://pixhost.to/)        |      -       | `https://img75.pixhost.to/images/69/{id}_img.png`    |
-| [postimages](https://postimages.org/) |      +       | `https://i.postimg.cc/{id}/img.png`                  |
-| [ptpimg](https://ptpimg.me/)          |      +       | `https://ptpimg.me/{id}.png`                         |
-| [sxcu](https://sxcu.net/)             |      -       | `https://sxcu.net/{id}.png`                          |
-| [thumbsnap](https://thumbsnap.com/)   |      +       | `https://thumbsnap.com/i/{id}.png`                   |
-| [tixte](https://tixte.com/)           |      +       | `https://{domain}.tixte.co/r/{id}.png`               |
-| [uplio](https://upl.io/)              |      +       | `https://upl.io/i/{id}.png`                          |
-| [uploadcare](https://uploadcare.com/) |      +       | `https://ucarecdn.com/{id}/img.png`                  |
-| [vgy](https://vgy.me/)                |      +       | `https://i.vgy.me/{id}.png`                          |
-| [zpic](https://zpic.biz/)             |      +       | `https://zpi.cx/b/{id}.png`                          |
+| host                                  | key required | return example                                             |
+| :------------------------------------ | :----------: | :--------------------------------------------------------- |
+| [beeimg](https://beeimg.com/)         |      -       | `https://beeimg.com/images/{id}.png`                       |
+| [catbox](https://catbox.moe/)         |      -       | `https://files.catbox.moe/{id}`                            |
+| [cloudinary](https://cloudinary.com/) |      +       | `https://res.cloudinary.com/{cloud}/image/upload/{id}.png` |
+| [fastpic](https://fastpic.org/)       |      -       | `https://i120.fastpic.org/big/2022/0730/d9/{id}.png`       |
+| [freeimage](https://freeimage.host/)  |      +       | `https://iili.io/{id}.png`                                 |
+| [gyazo](https://gyazo.com/)           |      +       | `https://i.gyazo.com/{id}.png`                             |
+| [imageban](https://imageban.ru/)      |      +       | `https://i2.imageban.ru/out/2022/07/30/{id}.png`           |
+| [imagekit](https://imagekit.io/)      |      +       | `https://ik.imagekit.io/{id}/img_{id}.png`                 |
+| [imgbb](https://imgbb.com/)           |      +       | `https://i.ibb.co/{id}/image.png`                          |
+| [imghippo](https://imghippo.com/)     |      +       | `https://i.imghippo.com/files/{id}.png`                    |
+| [imgbox](https://imgbox.com/)         |      -       | `https://images2.imgbox.com/52/8c/{id}_o.png`              |
+| [imgchest](https://imgchest.com/)     |      +       | `https://cdn.imgchest.com/files/{id}.png`                  |
+| [imgur](https://imgur.com/)           |      -       | `https://i.imgur.com/{id}.png`                             |
+| [lensdump](https://lensdump.com/)     |      +       | `https://i.lensdump.com/i/{id}.png`                        |
+| [pixeldrain](https://pixeldrain.com/) |      +       | `https://pixeldrain.com/api/file/{id}`                     |
+| [pixhost](https://pixhost.to/)        |      -       | `https://img75.pixhost.to/images/69/{id}_img.png`          |
+| [postimages](https://postimages.org/) |      +       | `https://i.postimg.cc/{id}/img.png`                        |
+| [ptpimg](https://ptpimg.me/)          |      +       | `https://ptpimg.me/{id}.png`                               |
+| [sxcu](https://sxcu.net/)             |      -       | `https://sxcu.net/{id}.png`                                |
+| [thumbsnap](https://thumbsnap.com/)   |      +       | `https://thumbsnap.com/i/{id}.png`                         |
+| [tixte](https://tixte.com/)           |      +       | `https://{domain}.tixte.co/r/{id}.png`                     |
+| [uplio](https://upl.io/)              |      +       | `https://upl.io/i/{id}.png`                                |
+| [uploadcare](https://uploadcare.com/) |      +       | `https://ucarecdn.com/{id}/img.png`                        |
+| [vgy](https://vgy.me/)                |      +       | `https://i.vgy.me/{id}.png`                                |
+| [zpic](https://zpic.biz/)             |      +       | `https://zpi.cx/b/{id}.png`                                |
 
 ## Usage
 
@@ -74,10 +77,15 @@ Options:
 ## Env Variables
 
 ```ini
+CLOUDINARY_CLOUD_NAME=
+CLOUDINARY_API_KEY=
+CLOUDINARY_API_SECRET=
 FREEIMAGE_KEY=
 GYAZO_TOKEN=
 IMAGEBAN_TOKEN=
+IMAGEKIT_PRIVATE_KEY=
 IMGBB_KEY=
+IMGHIPPO_KEY=
 IMGCHEST_KEY=
 IMGUR_CLIENT_ID=
 LENSDUMP_KEY=

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ yay -S imgup-bin
 | [cloudinary](https://cloudinary.com/) |      +       | `https://res.cloudinary.com/{cloud}/image/upload/{id}.png` |
 | [fastpic](https://fastpic.org/)       |      -       | `https://i120.fastpic.org/big/2022/0730/d9/{id}.png`       |
 | [freeimage](https://freeimage.host/)  |      +       | `https://iili.io/{id}.png`                                 |
+| [gofile](https://gofile.io/)          |      -       | `https://gofile.io/d/{id}`                                 |
 | [gyazo](https://gyazo.com/)           |      +       | `https://i.gyazo.com/{id}.png`                             |
 | [imageban](https://imageban.ru/)      |      +       | `https://i2.imageban.ru/out/2022/07/30/{id}.png`           |
 | [imagekit](https://imagekit.io/)      |      +       | `https://ik.imagekit.io/{id}/img_{id}.png`                 |

--- a/src/upload/cloudinary.rs
+++ b/src/upload/cloudinary.rs
@@ -1,0 +1,77 @@
+use anyhow::{Context, Result};
+use reqwest::Client;
+use reqwest::multipart::{Form, Part};
+use serde::Deserialize;
+
+use super::parse_json;
+use crate::image::get_image_ext;
+
+pub const API_URL: &str = "https://api.cloudinary.com/v1_1";
+
+#[derive(Deserialize)]
+struct Response {
+    secure_url: String,
+}
+
+/// Upload image bytes to cloudinary.com.
+///
+/// Requires cloud name, API key, and API secret.
+pub async fn upload(
+    client: &Client,
+    data: Vec<u8>,
+    url: &str,
+    api_key: &str,
+    api_secret: &str,
+) -> Result<String> {
+    let ext = get_image_ext(&data)?;
+    let ext_str = ext.extensions_str()[0];
+
+    let form = Form::new().part(
+        "file",
+        Part::bytes(data).file_name(format!("img.{ext_str}")),
+    );
+
+    let resp = client
+        .post(url)
+        .basic_auth(api_key, Some(api_secret))
+        .multipart(form)
+        .send()
+        .await
+        .context("failed to send request to cloudinary")?;
+
+    let resp: Response = parse_json(resp, "cloudinary").await?;
+    Ok(resp.secure_url)
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+mod tests {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_upload_success() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "secure_url": "https://res.cloudinary.com/demo/image/upload/v1/img.png",
+                "public_id": "img"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let png = crate::image::create_test_png();
+
+        let client = Client::new();
+        let url = upload(&client, png, &mock_server.uri(), "test_key", "test_secret")
+            .await
+            .unwrap();
+        assert_eq!(
+            url,
+            "https://res.cloudinary.com/demo/image/upload/v1/img.png"
+        );
+    }
+}

--- a/src/upload/gofile.rs
+++ b/src/upload/gofile.rs
@@ -1,0 +1,129 @@
+use anyhow::{Context, Result};
+use reqwest::Client;
+use reqwest::multipart::{Form, Part};
+use serde::Deserialize;
+
+use super::parse_json;
+use crate::image::get_image_ext;
+
+pub const API_URL: &str = "https://api.gofile.io/servers";
+
+#[derive(Deserialize)]
+struct ServersResponse {
+    data: ServersData,
+}
+
+#[derive(Deserialize)]
+struct ServersData {
+    servers: Vec<Server>,
+}
+
+#[derive(Deserialize)]
+struct Server {
+    name: String,
+}
+
+#[derive(Deserialize)]
+struct UploadResponse {
+    data: UploadData,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct UploadData {
+    download_page: String,
+}
+
+/// Upload image bytes to gofile.io.
+///
+/// No API key required.
+pub async fn upload(client: &Client, data: Vec<u8>, servers_url: &str) -> Result<String> {
+    let upload_url = get_server(client, servers_url).await?;
+    upload_to(client, data, &upload_url).await
+}
+
+async fn get_server(client: &Client, servers_url: &str) -> Result<String> {
+    let resp = client
+        .get(servers_url)
+        .send()
+        .await
+        .context("failed to fetch gofile server list")?;
+
+    let resp: ServersResponse = parse_json(resp, "gofile servers").await?;
+    let server = resp
+        .data
+        .servers
+        .into_iter()
+        .next()
+        .context("gofile returned no servers")?;
+
+    Ok(format!(
+        "https://{}.gofile.io/contents/uploadfile",
+        server.name
+    ))
+}
+
+async fn upload_to(client: &Client, data: Vec<u8>, upload_url: &str) -> Result<String> {
+    let ext = get_image_ext(&data)?;
+    let ext_str = ext.extensions_str()[0];
+
+    let form = Form::new().part(
+        "file",
+        Part::bytes(data).file_name(format!("img.{ext_str}")),
+    );
+
+    let resp = client
+        .post(upload_url)
+        .multipart(form)
+        .send()
+        .await
+        .context("failed to send request to gofile")?;
+
+    let resp: UploadResponse = parse_json(resp, "gofile").await?;
+    Ok(resp.data.download_page)
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+mod tests {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_server() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "status": "ok",
+                "data": {"servers": [{"name": "store1", "zone": "eu"}]}
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = Client::new();
+        let url = get_server(&client, &mock_server.uri()).await.unwrap();
+        assert_eq!(url, "https://store1.gofile.io/contents/uploadfile");
+    }
+
+    #[tokio::test]
+    async fn test_upload_to() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "status": "ok",
+                "data": {"downloadPage": "https://gofile.io/d/YxNORW"}
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let png = crate::image::create_test_png();
+
+        let client = Client::new();
+        let url = upload_to(&client, png, &mock_server.uri()).await.unwrap();
+        assert_eq!(url, "https://gofile.io/d/YxNORW");
+    }
+}

--- a/src/upload/imagekit.rs
+++ b/src/upload/imagekit.rs
@@ -1,0 +1,69 @@
+use anyhow::{Context, Result};
+use reqwest::Client;
+use reqwest::multipart::{Form, Part};
+use serde::Deserialize;
+
+use super::parse_json;
+use crate::image::get_image_ext;
+
+pub const API_URL: &str = "https://upload.imagekit.io/api/v1/files/upload";
+
+#[derive(Deserialize)]
+struct Response {
+    url: String,
+}
+
+/// Upload image bytes to imagekit.io.
+///
+/// Requires API key.
+pub async fn upload(client: &Client, data: Vec<u8>, url: &str, key: &str) -> Result<String> {
+    let ext = get_image_ext(&data)?;
+    let ext_str = ext.extensions_str()[0];
+    let filename = format!("img.{ext_str}");
+
+    let form = Form::new()
+        .text("fileName", filename.clone())
+        .part("file", Part::bytes(data).file_name(filename));
+
+    let resp = client
+        .post(url)
+        .basic_auth(key, Option::<&str>::None)
+        .multipart(form)
+        .send()
+        .await
+        .context("failed to send request to imagekit")?;
+
+    let resp: Response = parse_json(resp, "imagekit").await?;
+    Ok(resp.url)
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+mod tests {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_upload_success() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "fileId": "abc123",
+                "name": "img.png",
+                "url": "https://ik.imagekit.io/demo/img_demo.png"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let png = crate::image::create_test_png();
+
+        let client = Client::new();
+        let url = upload(&client, png, &mock_server.uri(), "test_key")
+            .await
+            .unwrap();
+        assert_eq!(url, "https://ik.imagekit.io/demo/img_demo.png");
+    }
+}

--- a/src/upload/imghippo.rs
+++ b/src/upload/imghippo.rs
@@ -1,0 +1,73 @@
+use anyhow::{Context, Result};
+use reqwest::Client;
+use reqwest::multipart::{Form, Part};
+use serde::Deserialize;
+
+use super::parse_json;
+use crate::image::get_image_ext;
+
+pub const API_URL: &str = "https://api.imghippo.com/v1/upload";
+
+#[derive(Deserialize)]
+struct Response {
+    data: Data,
+}
+
+#[derive(Deserialize)]
+struct Data {
+    url: String,
+}
+
+/// Upload image bytes to imghippo.com.
+///
+/// Requires API key.
+pub async fn upload(client: &Client, data: Vec<u8>, url: &str, key: &str) -> Result<String> {
+    let ext = get_image_ext(&data)?;
+    let ext_str = ext.extensions_str()[0];
+
+    let form = Form::new().text("api_key", key.to_owned()).part(
+        "file",
+        Part::bytes(data).file_name(format!("img.{ext_str}")),
+    );
+
+    let resp = client
+        .post(url)
+        .multipart(form)
+        .send()
+        .await
+        .context("failed to send request to imghippo")?;
+
+    let resp: Response = parse_json(resp, "imghippo").await?;
+    Ok(resp.data.url)
+}
+
+#[cfg(test)]
+#[expect(clippy::unwrap_used)]
+mod tests {
+    use wiremock::matchers::method;
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_upload_success() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "success": true,
+                "status": 200,
+                "data": {"url": "https://i.imghippo.com/files/abc123.png"}
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let png = crate::image::create_test_png();
+
+        let client = Client::new();
+        let url = upload(&client, png, &mock_server.uri(), "test_key")
+            .await
+            .unwrap();
+        assert_eq!(url, "https://i.imghippo.com/files/abc123.png");
+    }
+}

--- a/src/upload/mod.rs
+++ b/src/upload/mod.rs
@@ -3,6 +3,7 @@ mod catbox;
 mod cloudinary;
 mod fastpic;
 mod freeimage;
+mod gofile;
 mod gyazo;
 mod imageban;
 mod imagekit;
@@ -62,6 +63,7 @@ pub enum Hosting {
     Cloudinary,
     Fastpic,
     Freeimage,
+    Gofile,
     Gyazo,
     Imageban,
     Imagekit,
@@ -113,6 +115,7 @@ pub async fn upload(client: &Client, hosting: Hosting, data: Vec<u8>) -> Result<
             let key = get_env("FREEIMAGE_KEY")?;
             freeimage::upload(client, data, freeimage::API_URL, &key).await
         }
+        Hosting::Gofile => gofile::upload(client, data, gofile::API_URL).await,
         Hosting::Gyazo => {
             let token = get_env("GYAZO_TOKEN")?;
             gyazo::upload(client, data, gyazo::API_URL, &token).await

--- a/src/upload/mod.rs
+++ b/src/upload/mod.rs
@@ -1,12 +1,15 @@
 mod beeimg;
 mod catbox;
+mod cloudinary;
 mod fastpic;
 mod freeimage;
 mod gyazo;
 mod imageban;
+mod imagekit;
 mod imgbb;
 mod imgbox;
 mod imgchest;
+mod imghippo;
 mod imgur;
 mod lensdump;
 mod pixeldrain;
@@ -56,11 +59,14 @@ pub(crate) async fn response_text(resp: reqwest::Response, provider: &str) -> Re
 pub enum Hosting {
     Beeimg,
     Catbox,
+    Cloudinary,
     Fastpic,
     Freeimage,
     Gyazo,
     Imageban,
+    Imagekit,
     Imgbb,
+    Imghippo,
     Imgbox,
     Imgchest,
     Imgur,
@@ -96,6 +102,13 @@ pub async fn upload(client: &Client, hosting: Hosting, data: Vec<u8>) -> Result<
         Hosting::Fastpic => fastpic::upload(client, data, fastpic::API_URL).await,
         Hosting::Pixhost => pixhost::upload(client, data, pixhost::API_URL).await,
         Hosting::Sxcu => sxcu::upload(client, data, sxcu::API_URL).await,
+        Hosting::Cloudinary => {
+            let cloud_name = get_env("CLOUDINARY_CLOUD_NAME")?;
+            let api_key = get_env("CLOUDINARY_API_KEY")?;
+            let api_secret = get_env("CLOUDINARY_API_SECRET")?;
+            let url = format!("{}/{cloud_name}/image/upload", cloudinary::API_URL);
+            cloudinary::upload(client, data, &url, &api_key, &api_secret).await
+        }
         Hosting::Freeimage => {
             let key = get_env("FREEIMAGE_KEY")?;
             freeimage::upload(client, data, freeimage::API_URL, &key).await
@@ -108,9 +121,17 @@ pub async fn upload(client: &Client, hosting: Hosting, data: Vec<u8>) -> Result<
             let token = get_env("IMAGEBAN_TOKEN")?;
             imageban::upload(client, data, imageban::API_URL, &token).await
         }
+        Hosting::Imagekit => {
+            let key = get_env("IMAGEKIT_PRIVATE_KEY")?;
+            imagekit::upload(client, data, imagekit::API_URL, &key).await
+        }
         Hosting::Imgbb => {
             let key = get_env("IMGBB_KEY")?;
             imgbb::upload(client, data, imgbb::API_URL, &key).await
+        }
+        Hosting::Imghippo => {
+            let key = get_env("IMGHIPPO_KEY")?;
+            imghippo::upload(client, data, imghippo::API_URL, &key).await
         }
         Hosting::Imgbox => imgbox::upload(client, data, imgbox::API_URL).await,
         Hosting::Imgchest => {

--- a/src/upload/uplio.rs
+++ b/src/upload/uplio.rs
@@ -29,12 +29,13 @@ pub async fn upload(client: &Client, data: Vec<u8>, url: &str, key: &str) -> Res
 
     let text = response_text(resp, "uplio").await?;
 
-    // Convert "https://upl.io/UID.ext" to "https://upl.io/i/UID.ext"
+    // Convert "https://upl.io/UID[.ext]" to "https://upl.io/i/UID.ext"
     let Some((host, uid)) = text.rsplit_once('/') else {
         debug!("Response text:\n{text}");
         anyhow::bail!("unexpected uplio response format");
     };
-    Ok(format!("{host}/i/{uid}"))
+    let uid_base = uid.rsplit_once('.').map_or(uid, |(base, _)| base);
+    Ok(format!("{host}/i/{uid_base}.{ext_str}"))
 }
 
 #[cfg(test)]
@@ -50,7 +51,7 @@ mod tests {
         let mock_server = MockServer::start().await;
 
         Mock::given(method("POST"))
-            .respond_with(ResponseTemplate::new(200).set_body_string("https://upl.io/0w25y7.png"))
+            .respond_with(ResponseTemplate::new(200).set_body_string("https://upl.io/0w25y7"))
             .mount(&mock_server)
             .await;
 


### PR DESCRIPTION
- feat: add `cloudinary`, `gofile`, `imagekit`, `imghippo`
- fix(uplio): handle responses without file extension